### PR TITLE
Fix sorting mutation

### DIFF
--- a/mineflayer_brute.js
+++ b/mineflayer_brute.js
@@ -173,7 +173,7 @@ function saveState() {
 // Get next test account
 function getNextTestAccount() {
     // Sort accounts by priority and failure count
-    const sortedAccounts = testAccounts.sort((a, b) => {
+    const sortedAccounts = [...testAccounts].sort((a, b) => {
         const aState = state.accountStates[a.username];
         const bState = state.accountStates[b.username];
         


### PR DESCRIPTION
## Summary
- avoid mutating the testAccounts array when selecting next account

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684315bb9d4c83278f12af460fbb80a0