### PR TITLE
Add password file check

### DIFF
--- a/mineflayer_brute.js
+++ b/mineflayer_brute.js
@@ -91,6 +91,10 @@ const config = {
 };
 
 // Load and distribute passwords
+if (!fs.existsSync('passwords.txt')) {
+    console.error('Error: passwords.txt not found');
+    process.exit(1);
+}
 const allPasswords = fs.readFileSync('passwords.txt', 'utf8')
     .split('\n')
     .map(p => p.trim())


### PR DESCRIPTION
## Summary
- exit if `passwords.txt` is missing in `mineflayer_brute.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684315c66f4c8327bc4304f02b091b29